### PR TITLE
fix: use 'where' command on Windows for checking command existence

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,9 +14,11 @@ interface Requirement {
   authCmd?: string;
 }
 
-function commandExists(cmd: string): boolean {
+export function commandExists(cmd: string): boolean {
+  const isWindows = process.platform === 'win32';
+  const checkCmd = isWindows ? `where ${cmd}` : `which ${cmd}`;
   try {
-    execSync(`which ${cmd}`, { stdio: 'pipe' });
+    execSync(checkCmd, { stdio: 'pipe' });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
Fix \commandExists\ function to work on Windows by using \where\ command instead of \which\.

## Changes
- Use \where\ command on Windows, \which\ on other platforms
- Export \commandExists\ function for potential reuse